### PR TITLE
VIX-144 & VIX-180: Copy/Paste Issue & Display Preview Closing Issue

### DIFF
--- a/Common/Controls/MultiSelectTreeview.cs
+++ b/Common/Controls/MultiSelectTreeview.cs
@@ -290,7 +290,7 @@ namespace Common.Controls
 						// the initial click was 'valid' (ie. wasn't subject to the dodgy treenode full-width issue)
 						_clickedNodeWasInBounds = true;
 
-						if (ModifierKeys == Keys.None && (m_SelectedNodes.Contains(node))) {
+						if ((ModifierKeys == Keys.None || ModifierKeys == Keys.Control) && (m_SelectedNodes.Contains(node))) {
 							// Potential Drag Operation
 							// Let Mouse Up do select
 						} else {

--- a/Common/Controls/MultiSelectTreeview.cs
+++ b/Common/Controls/MultiSelectTreeview.cs
@@ -76,6 +76,8 @@ namespace Common.Controls
 		// to avoid sorting the list every time.
 		private bool _delaySortingSelectedNodes = false;
 		private bool _clickedNodeWasInBounds = false;
+		private bool _selectedNodeWithControlKey = false;
+
 		#endregion
 
 
@@ -290,11 +292,14 @@ namespace Common.Controls
 						// the initial click was 'valid' (ie. wasn't subject to the dodgy treenode full-width issue)
 						_clickedNodeWasInBounds = true;
 
-						if ((ModifierKeys == Keys.None || ModifierKeys == Keys.Control) && (m_SelectedNodes.Contains(node))) {
+						if ((ModifierKeys == Keys.None || ModifierKeys == Keys.Control) && (m_SelectedNodes.Contains(node)))
+						{
 							// Potential Drag Operation
 							// Let Mouse Up do select
 						} else {
 							SelectNode(node);
+							if (ModifierKeys == Keys.Control)
+								_selectedNodeWithControlKey = true;
 						}
 					}
 					// due to a weird issue in the TreeNode GetNodeAt() call, if we click off to the right of the nodes,
@@ -332,8 +337,11 @@ namespace Common.Controls
 				{
 					if (ModifierKeys == Keys.None && m_SelectedNodes.Contains(node) && e.Button != MouseButtons.Right && _clickedNodeWasInBounds)
 						SelectNode(node);
+					if (ModifierKeys == Keys.Control && !_selectedNodeWithControlKey)
+						SelectNode(node);
 				}
 
+				_selectedNodeWithControlKey = false;
 				base.OnMouseUp(e);
 			}
 			catch (Exception ex)

--- a/Common/Controls/MultiSelectTreeview.cs
+++ b/Common/Controls/MultiSelectTreeview.cs
@@ -345,6 +345,7 @@ namespace Common.Controls
 			{
 				HandleException(ex);
 			}
+			_selectedNodeWithControlKey = false;
 		}
 
 		protected override void OnItemDrag(ItemDragEventArgs e)

--- a/Common/Controls/MultiSelectTreeview.cs
+++ b/Common/Controls/MultiSelectTreeview.cs
@@ -76,8 +76,6 @@ namespace Common.Controls
 		// to avoid sorting the list every time.
 		private bool _delaySortingSelectedNodes = false;
 		private bool _clickedNodeWasInBounds = false;
-		private bool _selectedNodeWithControlKey = false;
-
 		#endregion
 
 
@@ -292,14 +290,11 @@ namespace Common.Controls
 						// the initial click was 'valid' (ie. wasn't subject to the dodgy treenode full-width issue)
 						_clickedNodeWasInBounds = true;
 
-						if ((ModifierKeys == Keys.None || ModifierKeys == Keys.Control) && (m_SelectedNodes.Contains(node)))
-						{
+						if ((ModifierKeys == Keys.None || ModifierKeys == Keys.Control) && (m_SelectedNodes.Contains(node))) {
 							// Potential Drag Operation
 							// Let Mouse Up do select
 						} else {
 							SelectNode(node);
-							if (ModifierKeys == Keys.Control)
-								_selectedNodeWithControlKey = true;
 						}
 					}
 					// due to a weird issue in the TreeNode GetNodeAt() call, if we click off to the right of the nodes,
@@ -337,11 +332,8 @@ namespace Common.Controls
 				{
 					if (ModifierKeys == Keys.None && m_SelectedNodes.Contains(node) && e.Button != MouseButtons.Right && _clickedNodeWasInBounds)
 						SelectNode(node);
-					if (ModifierKeys == Keys.Control && !_selectedNodeWithControlKey)
-						SelectNode(node);
 				}
 
-				_selectedNodeWithControlKey = false;
 				base.OnMouseUp(e);
 			}
 			catch (Exception ex)

--- a/Common/Controls/MultiSelectTreeview.cs
+++ b/Common/Controls/MultiSelectTreeview.cs
@@ -76,6 +76,7 @@ namespace Common.Controls
 		// to avoid sorting the list every time.
 		private bool _delaySortingSelectedNodes = false;
 		private bool _clickedNodeWasInBounds = false;
+		private bool _selectedNodeWithControlKey = false;
 		#endregion
 
 
@@ -294,6 +295,8 @@ namespace Common.Controls
 							// Potential Drag Operation
 							// Let Mouse Up do select
 						} else {
+							if (ModifierKeys == Keys.Control)
+								_selectedNodeWithControlKey = true;
 							SelectNode(node);
 						}
 					}
@@ -331,6 +334,8 @@ namespace Common.Controls
 				if (node != null)
 				{
 					if (ModifierKeys == Keys.None && m_SelectedNodes.Contains(node) && e.Button != MouseButtons.Right && _clickedNodeWasInBounds)
+						SelectNode(node);
+					if (ModifierKeys == Keys.Control && !_selectedNodeWithControlKey)
 						SelectNode(node);
 				}
 

--- a/Modules/Preview/DisplayPreview/Views/ViewManager.cs
+++ b/Modules/Preview/DisplayPreview/Views/ViewManager.cs
@@ -46,6 +46,7 @@ namespace VixenModules.Preview.DisplayPreview.Views
         {
             if (_view != null)
             {
+				_view.SystemClosing = true;
             	_view.Dispatcher.Invoke(DispatcherPriority.Normal, (Action)(() => _view.Close()));
             }
         }

--- a/Modules/Preview/DisplayPreview/Views/VisualizerView.xaml
+++ b/Modules/Preview/DisplayPreview/Views/VisualizerView.xaml
@@ -9,7 +9,7 @@
         mc:Ignorable="d"
         SizeToContent="WidthAndHeight"
         Title="Display Preview"
-        d:DataContext="{d:DesignInstance ViewModels:VisualizerViewModel}">
+        d:DataContext="{d:DesignInstance ViewModels:VisualizerViewModel}" Closing="DisplayPreview_Closing">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/Modules/Preview/DisplayPreview/Views/VisualizerView.xaml.cs
+++ b/Modules/Preview/DisplayPreview/Views/VisualizerView.xaml.cs
@@ -2,9 +2,24 @@
 {
     public partial class VisualizerView
     {
+
+		public bool SystemClosing { get; set; }
+
+
         public VisualizerView()
         {
             InitializeComponent();
         }
+
+		private void DisplayPreview_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+		{
+			if (!SystemClosing) {
+				System.Windows.MessageBox.Show("To close the Display Preview, click the 'Configure Previews' " +
+					"button on the main Vixen Administration window and then uncheck the preview in the list.",
+					"Close Display Preview");
+				e.Cancel = true;
+			}
+
+		}
     }
 }


### PR DESCRIPTION
Holding down control while doing a drag-n-drop now properly copies all
elements/groups, without deselecting the node being clicked on to
initiate the drag-n-drop.

Also, user can no longer close the Display Preview by clicking the X button on the window.
